### PR TITLE
new-hatch script refactored

### DIFF
--- a/packages/hardhat/params.ts
+++ b/packages/hardhat/params.ts
@@ -1,0 +1,108 @@
+import { ethers } from "ethers";
+
+const { BigNumber } = ethers;
+
+// Helpers, no need to change
+const HOURS = 60 * 60;
+const DAYS = 24 * HOURS;
+const ONE_HUNDRED_PERCENT = 1e18;
+const ONE_TOKEN = BigNumber.from((1e18).toString());
+const FUNDRAISING_ONE_HUNDRED_PERCENT = 1e6;
+const FUNDRAISING_ONE_TOKEN = BigNumber.from((1e18).toString());
+const PPM = 1000000;
+
+// Collateral Token is used to pay contributors and held in the bonding curve reserve
+const COLLATERAL_TOKEN = "0xfb8f60246d56905866e12443ec0836ebfb3e1f2e"; // tDAI
+
+// Org Token represents membership in the community and influence in proposals
+const ORG_TOKEN_NAME = "Token Engineering Commons TEST Hatch Token";
+const ORG_TOKEN_SYMBOL = "TESTTECH";
+
+// # Hatch Oracle Settings
+
+// Score membership token is used to check how much members can contribute to the hatch
+const SCORE_TOKEN = "0xc4fbe68522ba81a28879763c3ee33e08b13c499e"; // CSTK Token on xDai
+const SCORE_ONE_TOKEN = BigNumber.from(1);
+// Ratio contribution tokens allowed per score membership token
+const HATCH_ORACLE_RATIO = BigNumber.from(0.8 * PPM)
+  .mul(FUNDRAISING_ONE_TOKEN)
+  .div(SCORE_ONE_TOKEN);
+
+// # Dandelion Voting Settings
+// Used for administrative or binary choice decisions with ragequit-like functionality on Dandelion Voting
+const VOTE_DURATION = 3 * DAYS;
+const VOTE_BUFFER = 3 * DAYS;
+const VOTE_EXECUTION_DELAY = 24 * HOURS;
+const SUPPORT_REQUIRED = String(0.6 * ONE_HUNDRED_PERCENT);
+const MIN_ACCEPTANCE_QUORUM = String(0.02 * ONE_HUNDRED_PERCENT);
+
+// Set the fee paid to the org to create an administrative vote
+const TOLLGATE_FEE = BigNumber.from(3).mul(ONE_TOKEN);
+
+// # Hatch settings
+
+// How many COLLATERAL_TOKEN's are required to Hatch
+const HATCH_MIN_GOAL = BigNumber.from(5).mul(ONE_TOKEN);
+// What is the Max number of COLLATERAL_TOKEN's the Hatch can recieve
+const HATCH_MAX_GOAL = BigNumber.from(1000).mul(ONE_TOKEN);
+// How long should the hatch period last
+const HATCH_PERIOD = 15 * DAYS;
+// How many organization tokens should be minted per collateral token
+const HATCH_EXCHANGE_RATE = BigNumber.from(10000 * PPM)
+  .mul(ONE_TOKEN)
+  .div(FUNDRAISING_ONE_TOKEN);
+// When does the cliff for vesting restrictions end
+const VESTING_CLIFF_PERIOD = HATCH_PERIOD + 1; // 1 second after hatch
+// When will the Hatchers be fully vested and able to use the redemptions app
+const VESTING_COMPLETE_PERIOD = VESTING_CLIFF_PERIOD + 1; // 2 seconds after hatch
+// What percentage of Hatch contributions should go to the Funding Pool and therefore be non refundable
+const HATCH_TRIBUTE = 0.05 * FUNDRAISING_ONE_HUNDRED_PERCENT;
+// when should the Hatch open, setting 0 will allow anyone to open the Hatch anytime after deployment
+const OPEN_DATE = 0;
+
+// # Impact hours settings
+
+// Impact Hours token address
+const IH_TOKEN = "0xdf2c3c8764a92eb43d2eea0a4c2d77c2306b0835";
+// Max theoretical collateral token rate per impact hour
+const MAX_IH_RATE = BigNumber.from(100).mul(ONE_TOKEN);
+
+// How much will we need to raise to reach 1/2 of the MAX_IH_RATE divided by total IH
+const EXPECTED_RAISE_PER_IH = BigNumber.from(0.012 * 1000)
+  .mul(ONE_TOKEN)
+  .div(1000);
+
+const getParams = (blockTime) => ({
+  HOURS,
+  DAYS,
+  ONE_HUNDRED_PERCENT,
+  ONE_TOKEN,
+  FUNDRAISING_ONE_HUNDRED_PERCENT,
+  FUNDRAISING_ONE_TOKEN,
+  PPM,
+  COLLATERAL_TOKEN,
+  ORG_TOKEN_NAME,
+  ORG_TOKEN_SYMBOL,
+  SCORE_TOKEN,
+  SCORE_ONE_TOKEN,
+  HATCH_ORACLE_RATIO,
+  TOLLGATE_FEE,
+  HATCH_MIN_GOAL,
+  HATCH_MAX_GOAL,
+  HATCH_PERIOD,
+  HATCH_EXCHANGE_RATE,
+  VESTING_CLIFF_PERIOD,
+  VESTING_COMPLETE_PERIOD,
+  HATCH_TRIBUTE,
+  OPEN_DATE,
+  IH_TOKEN,
+  MAX_IH_RATE,
+  EXPECTED_RAISE_PER_IH,
+  SUPPORT_REQUIRED,
+  MIN_ACCEPTANCE_QUORUM,
+  VOTE_DURATION_BLOCKS: VOTE_DURATION / blockTime,
+  VOTE_BUFFER_BLOCKS: VOTE_BUFFER / blockTime,
+  VOTE_EXECUTION_DELAY_BLOCKS: VOTE_EXECUTION_DELAY / blockTime,
+});
+
+export default getParams;

--- a/packages/hardhat/scripts/new-hatch.ts
+++ b/packages/hardhat/scripts/new-hatch.ts
@@ -3,21 +3,22 @@ import { Contract } from "@ethersproject/contracts";
 import { Signer } from "@ethersproject/abstract-signer";
 import { ERC20, HatchTemplate, IHatch, IImpactHours, Kernel, MiniMeToken } from "../typechain";
 import { impersonateAddress } from "../helpers/rpc";
+import getParams from "../params";
 
 const { deployments } = hre;
-const { BigNumber } = ethers;
 
 export interface HatchContext {
   hatchUser?: Signer;
   dao?: Kernel;
   hatch?: IHatch;
   contributionToken?: ERC20;
-  hatchToken: ERC20;
-  impactHours: IImpactHours;
-  impactHoursClonedToken: MiniMeToken;
-  impactHoursToken: MiniMeToken;
+  hatchToken?: ERC20;
+  impactHours?: IImpactHours;
+  impactHoursClonedToken?: MiniMeToken;
+  impactHoursToken?: MiniMeToken;
 }
 
+// Script arguments
 const DAO_ID = "testtec" + Math.random(); // Note this must be unique for each deployment, change it for subsequent deployments
 const NETWORK_ARG = "--network";
 const DAO_ID_ARG = "--daoid";
@@ -28,85 +29,38 @@ const argValue = (arg, defaultValue) =>
 const network = () => argValue(NETWORK_ARG, "local");
 const daoId = () => argValue(DAO_ID_ARG, DAO_ID);
 
-// Helpers, no need to change
-const HOURS = 60 * 60;
-const DAYS = 24 * HOURS;
-const ONE_HUNDRED_PERCENT = 1e18;
-const ONE_TOKEN = BigNumber.from((1e18).toString());
-const FUNDRAISING_ONE_HUNDRED_PERCENT = 1e6;
-const FUNDRAISING_ONE_TOKEN = BigNumber.from((1e18).toString());
-const PPM = 1000000;
-
 const BLOCKTIME = network() === "rinkeby" ? 15 : network() === "mainnet" ? 13 : 5; // 15 rinkeby, 13 mainnet, 5 xdai
+
 console.log(`Every ${BLOCKTIME}s a new block is mined in ${network()}.`);
 
-// CONFIGURATION
-
-// Collateral Token is used to pay contributors and held in the bonding curve reserve
-const COLLATERAL_TOKEN = "0xfb8f60246d56905866e12443ec0836ebfb3e1f2e"; // tDAI
-
-// Org Token represents membership in the community and influence in proposals
-const ORG_TOKEN_NAME = "Token Engineering Commons TEST Hatch Token";
-const ORG_TOKEN_SYMBOL = "TESTTECH";
-
-// # Hatch Oracle Settings
-
-// Score membership token is used to check how much members can contribute to the hatch
-const SCORE_TOKEN = "0xc4fbe68522ba81a28879763c3ee33e08b13c499e"; // CSTK Token on xDai
-const SCORE_ONE_TOKEN = BigNumber.from(1);
-// Ratio contribution tokens allowed per score membership token
-const HATCH_ORACLE_RATIO = BigNumber.from(0.8 * PPM)
-  .mul(FUNDRAISING_ONE_TOKEN)
-  .div(SCORE_ONE_TOKEN);
-
-// # Dandelion Voting Settings
-
-// Used for administrative or binary choice decisions with ragequit-like functionality
-const SUPPORT_REQUIRED = String(0.6 * ONE_HUNDRED_PERCENT);
-const MIN_ACCEPTANCE_QUORUM = String(0.02 * ONE_HUNDRED_PERCENT);
-const VOTE_DURATION_BLOCKS = (3 * DAYS) / BLOCKTIME;
-const VOTE_BUFFER_BLOCKS = (8 * HOURS) / BLOCKTIME;
-const VOTE_EXECUTION_DELAY_BLOCKS = (24 * HOURS) / BLOCKTIME;
-// Set the fee paid to the org to create an administrative vote
-const TOLLGATE_FEE = BigNumber.from(3).mul(ONE_TOKEN);
-
-// # Hatch settings
-
-// How many COLLATERAL_TOKEN's are required to Hatch
-const HATCH_MIN_GOAL = BigNumber.from(5).mul(ONE_TOKEN);
-// What is the Max number of COLLATERAL_TOKEN's the Hatch can recieve
-const HATCH_MAX_GOAL = BigNumber.from(1000).mul(ONE_TOKEN);
-// How long should the hatch period last
-const HATCH_PERIOD = 15 * DAYS;
-// How many organization tokens should be minted per collateral token
-const HATCH_EXCHANGE_RATE = BigNumber.from(10000 * PPM)
-  .mul(ONE_TOKEN)
-  .div(FUNDRAISING_ONE_TOKEN);
-// When does the cliff for vesting restrictions end
-const VESTING_CLIFF_PERIOD = HATCH_PERIOD + 1; // 1 second after hatch
-// When will the Hatchers be fully vested and able to use the redemptions app
-const VESTING_COMPLETE_PERIOD = VESTING_CLIFF_PERIOD + 1; // 2 seconds after hatch
-// What percentage of Hatch contributions should go to the Funding Pool and therefore be non refundable
-const HATCH_TRIBUTE = 0.05 * FUNDRAISING_ONE_HUNDRED_PERCENT;
-// when should the Hatch open, setting 0 will allow anyone to open the Hatch anytime after deployment
-const OPEN_DATE = 0;
-
-// # Impact hours settings
-
-// Impact Hours token address
-const IH_TOKEN = "0xdf2c3c8764a92eb43d2eea0a4c2d77c2306b0835";
-// Max theoretical collateral token rate per impact hour
-const MAX_IH_RATE = BigNumber.from(100).mul(ONE_TOKEN);
-
-// How much will we need to raise to reach 1/2 of the MAX_IH_RATE divided by total IH
-const EXPECTED_RAISE_PER_IH = BigNumber.from(0.012 * 1000)
-  .mul(ONE_TOKEN)
-  .div(1000);
+const {
+  ORG_TOKEN_NAME,
+  ORG_TOKEN_SYMBOL,
+  SUPPORT_REQUIRED,
+  MIN_ACCEPTANCE_QUORUM,
+  VOTE_DURATION_BLOCKS,
+  VOTE_BUFFER_BLOCKS,
+  VOTE_EXECUTION_DELAY_BLOCKS,
+  COLLATERAL_TOKEN,
+  IH_TOKEN,
+  EXPECTED_RAISE_PER_IH,
+  ONE_TOKEN,
+  HATCH_MIN_GOAL,
+  HATCH_MAX_GOAL,
+  HATCH_PERIOD,
+  HATCH_EXCHANGE_RATE,
+  VESTING_CLIFF_PERIOD,
+  VESTING_COMPLETE_PERIOD,
+  HATCH_TRIBUTE,
+  OPEN_DATE,
+  MAX_IH_RATE,
+  TOLLGATE_FEE,
+  SCORE_TOKEN,
+  HATCH_ORACLE_RATIO,
+} = getParams(BLOCKTIME);
 
 // There are multiple ERC20 paths. We need to specify one.
 const ERC20Path = "@aragon/os/contracts/lib/token/ERC20.sol:ERC20";
-// Address use to perform hatch operations
-const HATCH_USER = "0xDc2aDfA800a1ffA16078Ef8C1F251D50DcDa1065";
 
 const hatchTemplateAddress = async () => (await deployments.get("HatchTemplate")).address;
 
@@ -165,7 +119,7 @@ const createDaoTxOne = async (context: HatchContext, appManager: Signer, log: Fu
 
 const createDaoTxTwo = async (context: HatchContext, appManager: Signer, log: Function): Promise<void> => {
   const hatchTemplate = await getHatchTemplate(appManager);
-  const hatchUser = context.hatchUser;
+  const hatchUser = context.hatchUser ? context.hatchUser : appManager;
   const impactHoursToken = (await ethers.getContractAt("MiniMeToken", IH_TOKEN, appManager)) as MiniMeToken;
 
   const totalImpactHours = await impactHoursToken.totalSupply();
@@ -218,7 +172,7 @@ const createDaoTxThree = async (context: HatchContext, appManager: Signer, log: 
   const hatchTemplate = await getHatchTemplate(appManager);
 
   const tx = await hatchTemplate.createDaoTxThree(
-    DAO_ID,
+    daoId(),
     [COLLATERAL_TOKEN],
     COLLATERAL_TOKEN,
     TOLLGATE_FEE,
@@ -231,11 +185,13 @@ const createDaoTxThree = async (context: HatchContext, appManager: Signer, log: 
   log(`Tx three completed: Tollgate, Redemptions and Conviction Voting apps set up.`);
 };
 
-export default async function main(log = console.log) {
+export default async function main(hatchUserAddress?: string, log = console.log) {
   const hatchTemplateContext = {} as HatchContext;
   const appManager = await ethers.getSigners()[0];
 
-  hatchTemplateContext.hatchUser = await impersonateAddress(HATCH_USER);
+  if (hatchUserAddress) {
+    hatchTemplateContext.hatchUser = await impersonateAddress(hatchUserAddress);
+  }
 
   await createDaoTxOne(hatchTemplateContext, appManager, log);
   await createDaoTxTwo(hatchTemplateContext, appManager, log);

--- a/packages/hardhat/test/hatch.ts
+++ b/packages/hardhat/test/hatch.ts
@@ -1,13 +1,10 @@
-import { Signer } from "@ethersproject/abstract-signer";
 import { ethers } from "hardhat";
 import { use, assert } from "chai";
-import { getContributors, log } from "./helpers/helpers";
+import { claimRewards, log } from "./helpers/helpers";
 import { solidity } from "ethereum-waffle";
 import { assertBn } from "@aragon/contract-helpers-test/src/asserts";
 
-import newHatch from "../scripts/new-hatch";
-import { impersonateAddress } from "../helpers/rpc";
-import { Kernel, IHatch, IImpactHours, ERC20, MiniMeToken } from "../typechain";
+import { default as newHatch, HatchContext } from "../scripts/new-hatch";
 import { BigNumber } from "@ethersproject/bignumber";
 import { getStateByKey, STATE_CLOSED, STATE_FUNDING, STATE_GOAL_REACHED } from "./helpers/hatch-states";
 import { HATCH_ERRORS, IMPACT_HOURS_ERRORS, TOKEN_ERRORS } from "./helpers/errors";
@@ -15,129 +12,100 @@ import { calculateRewards } from "./helpers/helpers";
 
 use(solidity);
 
-// There are multiple ERC20 paths. We need to specify one.
-const ERC20Path = "@aragon/os/contracts/lib/token/ERC20.sol:ERC20";
-const HATCH_USER = "0xDc2aDfA800a1ffA16078Ef8C1F251D50DcDa1065";
 const MIN_NEGLIGIBLE_AMOUNT = ethers.BigNumber.from(String("10000000"));
 
-async function claimRewards(impactHours: IImpactHours, impactHoursTokenAddress: string): Promise<void> {
-  const CONTRIBUTORS_PROCESSED_PER_TRANSACTION = 10;
-  const contributors = await getContributors(impactHoursTokenAddress);
-  const total = Math.ceil(contributors.length / CONTRIBUTORS_PROCESSED_PER_TRANSACTION);
-  let counter = 1;
-  let tx;
-
-  for (let i = 0; i < contributors.length; i += CONTRIBUTORS_PROCESSED_PER_TRANSACTION) {
-    // Claim rewards might get too expensive so we set gasPrice to 1
-    tx = await impactHours.claimReward(contributors.slice(i, i + CONTRIBUTORS_PROCESSED_PER_TRANSACTION), {
-      gasPrice: 1,
-    });
-
-    await tx.wait();
-
-    log(
-      `Tx ${counter++} of ${total}: Rewards claimed for IH token holders ${i + 1} to ${Math.min(
-        i + CONTRIBUTORS_PROCESSED_PER_TRANSACTION,
-        contributors.length
-      )}.`,
-      10
-    );
-  }
-}
-
-describe("Hatch Flow", function () {
-  let hatchUser: Signer;
-  let dao: Kernel;
-  let hatch: IHatch;
-  let impactHours: IImpactHours;
-  let contributionToken: ERC20;
-  let hatchToken: ERC20;
-  let impactHoursClonedToken: ERC20;
-  let impactHoursTokenAddress: string;
+describe("Hatch Flow", () => {
+  let hatchContext: HatchContext;
 
   before(async () => {
-    const [daoAddress, hatchAddress, impactHoursAddress] = await newHatch();
-
-    hatchUser = await impersonateAddress(HATCH_USER);
-    dao = (await ethers.getContractAt("Kernel", daoAddress)) as Kernel;
-    hatch = (await ethers.getContractAt("IHatch", hatchAddress, hatchUser)) as IHatch;
-    impactHours = (await ethers.getContractAt("IImpactHours", impactHoursAddress, hatchUser)) as IImpactHours;
-    contributionToken = (await ethers.getContractAt(ERC20Path, await hatch.contributionToken(), hatchUser)) as ERC20;
-    hatchToken = (await ethers.getContractAt(ERC20Path, await hatch.token(), hatchUser)) as ERC20;
-    impactHoursClonedToken = (await ethers.getContractAt(
-      "MiniMeToken",
-      await impactHours.token(),
-      hatchUser
-    )) as MiniMeToken;
-    impactHoursTokenAddress = await impactHoursClonedToken.parentToken();
+    hatchContext = await newHatch(log);
   });
 
   context("When max goal is reached", async () => {
     it("opens the hatch", async function () {
-      const tx = await hatch.open();
+      const tx = await hatchContext.hatch.open();
 
       await tx.wait();
 
-      assert.strictEqual(getStateByKey(await hatch.state()), STATE_FUNDING, HATCH_ERRORS.ERROR_HATCH_NOT_OPENED);
+      assert.strictEqual(
+        getStateByKey(await hatchContext.hatch.state()),
+        STATE_FUNDING,
+        HATCH_ERRORS.ERROR_HATCH_NOT_OPENED
+      );
     });
 
     it("contributes with a max goal amount to the hatch", async () => {
       let tx;
-      const maxGoalContribution = await hatch.maxGoal();
+      const maxGoalContribution = await hatchContext.hatch.maxGoal();
 
-      tx = await contributionToken.approve(hatch.address, maxGoalContribution);
+      tx = await hatchContext.contributionToken.approve(hatchContext.hatch.address, maxGoalContribution);
 
       await tx.wait();
 
       assertBn(
-        await contributionToken.allowance(HATCH_USER, hatch.address),
+        await hatchContext.contributionToken.allowance(
+          await hatchContext.hatchUser.getAddress(),
+          hatchContext.hatch.address
+        ),
         maxGoalContribution,
         TOKEN_ERRORS.ERROR_APPROVAL_MISMATCH
       );
 
-      tx = await hatch.contribute(maxGoalContribution);
+      tx = await hatchContext.hatch.contribute(maxGoalContribution);
 
       await tx.wait();
 
       assertBn(
-        await contributionToken.balanceOf(hatch.address),
+        await hatchContext.contributionToken.balanceOf(hatchContext.hatch.address),
         maxGoalContribution,
         HATCH_ERRORS.ERROR_CONTRIBUTION_NOT_MADE
       );
 
-      assert.equal(getStateByKey(await hatch.state()), STATE_GOAL_REACHED, HATCH_ERRORS.ERROR_HATCH_GOAL_NOT_REACHED);
+      assert.equal(
+        getStateByKey(await hatchContext.hatch.state()),
+        STATE_GOAL_REACHED,
+        HATCH_ERRORS.ERROR_HATCH_GOAL_NOT_REACHED
+      );
     });
 
     it("claims the impact hours for all contributors", async () => {
-      const totalRaised = await hatch.totalRaised();
-      const totalIH = await impactHoursClonedToken.totalSupply();
-      const totalIHRewards = await calculateRewards(impactHours, totalRaised, totalIH);
-      const expectedHatchTokens = await hatch.contributionToTokens(totalIHRewards);
-      const hatchTokenTotalSupply = await hatchToken.totalSupply();
+      const totalRaised = await hatchContext.hatch.totalRaised();
+      const totalIH = await hatchContext.impactHoursClonedToken.totalSupply();
+      const totalIHRewards = await calculateRewards(hatchContext.impactHours, totalRaised, totalIH);
+      const expectedHatchTokens = await hatchContext.hatch.contributionToTokens(totalIHRewards);
+      const hatchTokenTotalSupply = await hatchContext.hatchToken.totalSupply();
 
-      await claimRewards(impactHours, impactHoursTokenAddress);
+      await claimRewards(hatchContext.impactHours, hatchContext.impactHoursToken);
 
       assert.isTrue(
         hatchTokenTotalSupply
           .add(expectedHatchTokens)
-          .sub(await hatchToken.totalSupply())
+          .sub(await hatchContext.hatchToken.totalSupply())
           .lt(MIN_NEGLIGIBLE_AMOUNT),
         IMPACT_HOURS_ERRORS.ERROR_CLAIMED_REWARDS_MISMATCH
       );
 
       assertBn(
-        await impactHoursClonedToken.totalSupply(),
+        await hatchContext.impactHoursClonedToken.totalSupply(),
         BigNumber.from(0),
         IMPACT_HOURS_ERRORS.ERROR_ALL_TOKENS_NOT_DESTROYED
       );
     });
 
     it("closes the hatch", async () => {
-      const tx = await impactHours.closeHatch();
+      const tx = await hatchContext.impactHours.closeHatch();
 
       await tx.wait();
 
-      assert.equal(getStateByKey(await hatch.state()), STATE_CLOSED, HATCH_ERRORS.ERROR_HATCH_NOT_CLOSED);
+      assert.equal(getStateByKey(await hatchContext.hatch.state()), STATE_CLOSED, HATCH_ERRORS.ERROR_HATCH_NOT_CLOSED);
     });
   });
+
+  // context("When none goal is reached", async () => {
+
+  //   it('closes the hatch when funding period is over', async () =>{
+  //     let tx
+
+  //   })
+  // }
 });

--- a/packages/hardhat/test/helpers/helpers.ts
+++ b/packages/hardhat/test/helpers/helpers.ts
@@ -1,41 +1,12 @@
-import { ethers } from "hardhat";
-import { Contract } from "@ethersproject/contracts";
 import { BigNumber } from "@ethersproject/bignumber";
 
 import fetch from "node-fetch";
 
-import { ERC20, IHatch, IImpactHours, Kernel, MiniMeToken } from "../../typechain/index";
+import { IImpactHours, MiniMeToken } from "../../typechain/index";
 
-export async function getAddress(selectedFilter: string, contract: Contract, transactionHash: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const filter = contract.filters[selectedFilter]();
-
-    contract.on(filter, (contractAddress, event) => {
-      if (event.transactionHash === transactionHash) {
-        contract.removeAllListeners(filter);
-        resolve(contractAddress);
-      }
-    });
-  });
-}
-
-export async function getAppAddresses(dao: Kernel, ensNames: string[]): Promise<string[]> {
-  return new Promise((resolve, reject) => {
-    const inputAppIds = ensNames.map(ethers.utils.namehash);
-    const proxies: string[] = [];
-
-    dao.on("NewAppProxy", (proxy, isUpgradeable, appId, event) => {
-      const index = inputAppIds.indexOf(appId);
-      if (index >= 0) {
-        proxies[index] = proxy;
-      }
-      if (proxies.length === ensNames.length) {
-        dao.removeAllListeners("NewAppProxy");
-        resolve(proxies);
-      }
-    });
-  });
-}
+export const now = (): BigNumber => {
+  return BigNumber.from(Math.floor(new Date().getTime() / 1000));
+};
 
 export const calculateRewards = async (
   impactHours: IImpactHours,

--- a/packages/hardhat/test/helpers/helpers.ts
+++ b/packages/hardhat/test/helpers/helpers.ts
@@ -1,7 +1,41 @@
-import { BigNumber } from "ethers";
+import { ethers } from "hardhat";
+import { Contract } from "@ethersproject/contracts";
+import { BigNumber } from "@ethersproject/bignumber";
+
 import fetch from "node-fetch";
 
-import { IImpactHours } from "../../typechain/index";
+import { ERC20, IHatch, IImpactHours, Kernel, MiniMeToken } from "../../typechain/index";
+
+export async function getAddress(selectedFilter: string, contract: Contract, transactionHash: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const filter = contract.filters[selectedFilter]();
+
+    contract.on(filter, (contractAddress, event) => {
+      if (event.transactionHash === transactionHash) {
+        contract.removeAllListeners(filter);
+        resolve(contractAddress);
+      }
+    });
+  });
+}
+
+export async function getAppAddresses(dao: Kernel, ensNames: string[]): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const inputAppIds = ensNames.map(ethers.utils.namehash);
+    const proxies: string[] = [];
+
+    dao.on("NewAppProxy", (proxy, isUpgradeable, appId, event) => {
+      const index = inputAppIds.indexOf(appId);
+      if (index >= 0) {
+        proxies[index] = proxy;
+      }
+      if (proxies.length === ensNames.length) {
+        dao.removeAllListeners("NewAppProxy");
+        resolve(proxies);
+      }
+    });
+  });
+}
 
 export const calculateRewards = async (
   impactHours: IImpactHours,
@@ -14,7 +48,7 @@ export const calculateRewards = async (
   return balance.mul(maxRate).div(String(1e18)).mul(totalRaised).div(totalRaised.add(expectedRaise));
 };
 
-export const getContributors = async (tokenAddress) => {
+export const getContributors = async (tokenAddress: string): Promise<string[]> => {
   return fetch("https://api.thegraph.com/subgraphs/name/aragon/aragon-tokens-xdai", {
     method: "POST",
     body: JSON.stringify({
@@ -31,4 +65,29 @@ export const getContributors = async (tokenAddress) => {
     .then((res) => res.data.tokenHolders.map(({ address }) => address));
 };
 
-export const log = (message, spaces = 4) => console.log(`${" ".repeat(spaces)}⚡ ${message}`);
+export async function claimRewards(impactHours: IImpactHours, impactHoursToken: MiniMeToken): Promise<void> {
+  const CONTRIBUTORS_PROCESSED_PER_TRANSACTION = 10;
+  const contributors = await getContributors(impactHoursToken.address);
+  const total = Math.ceil(contributors.length / CONTRIBUTORS_PROCESSED_PER_TRANSACTION);
+  let counter = 1;
+  let tx;
+
+  for (let i = 0; i < contributors.length; i += CONTRIBUTORS_PROCESSED_PER_TRANSACTION) {
+    // Claim rewards might get too expensive so we set gasPrice to 1
+    tx = await impactHours.claimReward(contributors.slice(i, i + CONTRIBUTORS_PROCESSED_PER_TRANSACTION), {
+      gasPrice: 1,
+    });
+
+    await tx.wait();
+
+    log(
+      `Tx ${counter++} of ${total}: Rewards claimed for IH token holders ${i + 1} to ${Math.min(
+        i + CONTRIBUTORS_PROCESSED_PER_TRANSACTION,
+        contributors.length
+      )}.`,
+      10
+    );
+  }
+}
+
+export const log = (message: string, spaces = 4): void => console.log(`${" ".repeat(spaces)}⚡ ${message}`);


### PR DESCRIPTION
This PR includes a new-hatch script refactoring.

- `createDaoTx` Hatch Template functions rearranged on their own functions. 
- The script now returns a `HatchContext` object containing all the contract handlers needed for the tests.
- Unused variables removed and `HatchTemplate` constants refactored.